### PR TITLE
Clarify snapshot CLI and workflow: add --test/--pcb-only guidance and examples

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -118,10 +118,24 @@ Common formats
 - `gltf` / `glb`
 - `kicad-library`
 
-8) Regression snapshots
-- `tsci snapshot`
-- `tsci snapshot -u` (update)
-- `tsci snapshot --3d` (include 3D)
+8) Visual snapshots for analysis and verification
+- `tsci snapshot` generates visual outputs (schematic/PCB, optionally 3D) and writes/overwrites snapshots by default.
+- Use these visuals to inspect placement, orientation, and overall circuit understanding during iteration.
+- `tsci snapshot --test` switches to regression-test mode: it fails on visual diffs and does **not** overwrite snapshots.
+- `tsci snapshot --pcb-only` generates only PCB visuals, which is especially useful for placement-focused iteration.
+- `tsci snapshot --3d` includes 3D snapshots in the output.
+
+Recommended pattern:
+```bash
+# During development: generate fresh visuals for analysis and review
+tsci snapshot
+
+# During placement-heavy iterations: focus only on PCB output
+tsci snapshot --pcb-only
+
+# In CI/regression checks: detect unexpected visual changes without overwriting
+tsci snapshot --test
+```
 
 9) Auth / publish
 - `tsci login` (browser-based)

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -32,7 +32,9 @@
 
 7) Stabilize and regression-test
 - Use `tsci build` in CI or before sharing.
-- Use `tsci snapshot` when you want visual regression checks for PCB/schematic.
+- Use `tsci snapshot` to generate visuals that help with placement analysis and quick circuit understanding.
+- Use `tsci snapshot --pcb-only` when you want a fast, placement-focused PCB view without schematic snapshots.
+- Use `tsci snapshot --test` in CI/regression checks to prevent overwriting snapshots and catch unexpected visual diffs.
 
 8) Export what you need
 - `tsci export` for SVG/netlist/DSN/3D/library


### PR DESCRIPTION
### Motivation
- Make the `tsci snapshot` behavior and flags clearer for both interactive development and CI/regression use.
- Provide a recommended pattern for using snapshots during development, placement iteration, and automated checks.

### Description
- Expanded `CLI.md` with a new "Visual snapshots for analysis and verification" section describing `tsci snapshot`, `--test`, `--pcb-only`, and `--3d` behavior and intended usage.
- Added a short recommended usage pattern (three example commands) showing typical development, placement-focused, and CI/regression workflows.
- Updated `WORKFLOW.md` to reference the new snapshot guidance and recommend `tsci snapshot --pcb-only` for fast placement views and `tsci snapshot --test` for CI checks.
- Left other CLI and workflow guidance intact while emphasizing that `--test` prevents overwriting snapshots and fails on visual diffs.

### Testing
- No automated code tests were run because this change is documentation-only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a5de7f0548832ea6c7d7188a8b2899)