### PR TITLE
docs: require `tsci check netlist` before placement and build

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -91,7 +91,11 @@ Tip: If someone has already imported the part, prefer the registry version—it 
 
 6) Build (generate circuit.json)
 
-Before building, it can be a good idea to check placement of the entire board or a specific component with `tsci check placement [file] [refdes]`
+Before placement checks or builds, run a netlist check first:
+- `tsci check netlist [file]`
+
+Then check placement of the entire board or a specific component:
+- `tsci check placement [file] [refdes]`
 
 - `tsci build` (auto-detects entrypoint)
 - `tsci build path/to/file.circuit.tsx`

--- a/SKILL.md
+++ b/SKILL.md
@@ -42,12 +42,14 @@ When this Skill is active:
 - Use `<trace />` for connectivity; prefer net connections (`net.GND`, `net.VCC`, etc.) for power/ground.
 
 5) Build and iterate
+- Run `tsci check netlist` before `tsci check placement` and `tsci build` to catch connectivity issues early.
 - Run `tsci build` to compile and validate the circuit.
 - DRC (Design Rule Check) errors can often be ignored during development—focus on getting the circuit correct first.
 - If routing struggles, reduce density, use `<group />` for sub-layouts, or change autorouter settings.
 - Use `tsci dev` only when you need interactive visual feedback (not typical for AI-driven iteration).
 
 6) Validate and export
+- Run `tsci check netlist` before `tsci check placement` and `tsci build` when preparing to share/publish.
 - Run `tsci build` (and optionally `tsci snapshot`) before sharing/publishing.
 - Use `tsci export` for SVG/netlist/DSN/3D/library outputs.
 - For manufacturing, obtain fabrication outputs (Gerbers/BOM/PnP) from the export UI after `tsci dev`.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -67,6 +67,7 @@
 
 ## 7) Iterate with `tsci build`
 
+- Run `tsci check netlist` before `tsci check placement` and `tsci build` to catch connectivity issues early.
 - Run `tsci build` to validate changes—this is the preferred iteration method for AI-driven development.
 - DRC (Design Rule Check) errors can often be ignored during development; focus on connectivity and component placement first.
 - Fix connectivity errors first, then placement, then routing.


### PR DESCRIPTION
### Motivation
- Catch connectivity errors earlier in the workflow by validating the netlist before running placement or full builds. 
- Make the recommended developer and CLI guidance explicit so users follow a reliable sequence: netlist → placement → build.

### Description
- Added guidance to `CLI.md` to run `tsci check netlist [file]` before `tsci check placement [file] [refdes]` and `tsci build`.
- Updated `SKILL.md` to include `tsci check netlist` in the default workflow both during iteration and before sharing/publishing.
- Updated `WORKFLOW.md` to require `tsci check netlist` prior to `tsci check placement` and `tsci build` in the iterate section.

### Testing
- Ran `bunx tsc --noEmit`, which exited non-zero because the repository contains no TypeScript project `tsconfig.json` and printed TypeScript help.  
- Ran `bun run format`, which failed because there is no `format` script defined in this repository's `package.json`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab6bb279dc832ea5b8613d293a3b36)