### PR TITLE
Add `tsci snapshot` guidance before routing checks

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -94,6 +94,9 @@ Tip: If someone has already imported the part, prefer the registry version—it 
 Before placement checks or builds, run a netlist check first:
 - `tsci check netlist [file]`
 
+Then generate a placement snapshot before routing checks:
+- `tsci snapshot`
+
 Then check placement of the entire board or a specific component:
 - `tsci check placement [file] [refdes]`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -43,6 +43,7 @@ When this Skill is active:
 
 5) Build and iterate
 - Run `tsci check netlist` before `tsci check placement` and `tsci build` to catch connectivity issues early.
+- Run `tsci snapshot` to inspect placement before checking routing.
 - Run `tsci build` to compile and validate the circuit.
 - DRC (Design Rule Check) errors can often be ignored during development—focus on getting the circuit correct first.
 - If routing struggles, reduce density, use `<group />` for sub-layouts, or change autorouter settings.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -70,7 +70,9 @@
 - Run `tsci check netlist` before `tsci check placement` and `tsci build` to catch connectivity issues early.
 - Run `tsci build` to validate changes—this is the preferred iteration method for AI-driven development.
 - DRC (Design Rule Check) errors can often be ignored during development; focus on connectivity and component placement first.
-- Fix connectivity errors first, then placement, then routing.
+- Fix connectivity errors first, then placement.
+- Run `tsci snapshot` to inspect placement before checking routing.
+- Then address routing issues.
 - Use `tsci dev` only when interactive visual preview is needed (not typical for AI iteration).
 
 ## 8) Stabilize and regression-test


### PR DESCRIPTION
### Motivation
- Improve the placement-to-routing workflow by encouraging a visual inspection step to catch placement/orientation issues before routing is attempted.
- Reduce wasted autorouter effort and make debugging placement-related problems easier by surfacing visuals early with `tsci snapshot`.

### Description
- Add a step to `CLI.md` to run `tsci snapshot` after `tsci check netlist` and before `tsci check placement`.
- Insert guidance into `SKILL.md` to `Run `tsci snapshot` to inspect placement before checking routing` in the build/iterate checklist.
- Update `WORKFLOW.md` to explicitly recommend running `tsci snapshot` to inspect placement prior to routing and to reorder the routing guidance accordingly.

### Testing
- Ran `bun run format`, which failed because there is no `format` script defined in this repository.
- Ran `bunx tsc --noEmit`, which did not run a project typecheck because there is no `tsconfig.json` in this repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab7352b974832e819533c138560f2f)