### PR TITLE
docs: document `tsci search --json` with output example

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -30,6 +30,7 @@ Search flags:
 - `--jlcpcb` (or `--lcsc`) – Search JLCPCB/LCSC components by name or part number
 - `--kicad` – Search KiCad footprint library
 - `--tscircuit` – Search tscircuit registry packages
+- `--json` – Return machine-readable JSON output instead of plain text
 
 Examples:
 ```bash
@@ -56,6 +57,23 @@ tsci search --tscircuit "LED"
 
 # Search without flags (searches all sources)
 tsci search "ESP32"
+
+# Search with JSON output (useful for scripts)
+tsci search --jlcpcb "ATmega328" --json
+# Example output:
+# {
+#   "results": [
+#     {
+#       "source": "jlcpcb",
+#       "name": "ATMEGA328P-AU",
+#       "part_number": "C14877",
+#       "description": "Microcontroller Unit, 8-bit AVR",
+#       "manufacturer": "Microchip Tech",
+#       "stock": 20226,
+#       "price": "0.735"
+#     }
+#   ]
+# }
 ```
 
 4) Add existing registry packages to your project


### PR DESCRIPTION
### Motivation
- Make the CLI primer explain the `--json` output mode so scripts and automation can consume `tsci search` reliably.

### Description
- Add `--json` to the list of `tsci search` flags and document that it returns machine-readable JSON.
- Add a concrete example command `tsci search --jlcpcb "ATmega328" --json` and include a representative JSON payload demonstrating the expected fields and structure.
- Update made to `CLI.md` to include the flag description and example.

### Testing
- Ran `bunx tsc --noEmit` to typecheck and it failed because there is no `tsconfig.json` in the repository root, so no TypeScript project could be validated.
- Ran `bun run format` and it failed because no `format` script is defined in `package.json` for this repo, so formatting could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab76f93a78832eaa779f07f9aa91fb)