### PR TITLE
Recommend `tsci check routing-difficulty` after placement

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -118,6 +118,9 @@ Then generate a placement snapshot before routing checks:
 Then check placement of the entire board or a specific component:
 - `tsci check placement [file] [refdes]`
 
+After placement, identify potential congestion before routing:
+- `tsci check routing-difficulty [file]`
+
 - `tsci build` (auto-detects entrypoint)
 - `tsci build path/to/file.circuit.tsx`
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -44,6 +44,7 @@ When this Skill is active:
 5) Build and iterate
 - Run `tsci check netlist` before `tsci check placement` and `tsci build` to catch connectivity issues early.
 - Run `tsci snapshot` to inspect placement before checking routing.
+- Run `tsci check routing-difficulty` after placement to identify potential areas of congestion.
 - Run `tsci build` to compile and validate the circuit.
 - DRC (Design Rule Check) errors can often be ignored during development—focus on getting the circuit correct first.
 - If routing struggles, reduce density, use `<group />` for sub-layouts, or change autorouter settings.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -72,6 +72,7 @@
 - DRC (Design Rule Check) errors can often be ignored during development; focus on connectivity and component placement first.
 - Fix connectivity errors first, then placement.
 - Run `tsci snapshot` to inspect placement before checking routing.
+- Run `tsci check routing-difficulty` after placement to identify potential areas of congestion.
 - Then address routing issues.
 - Use `tsci dev` only when interactive visual preview is needed (not typical for AI iteration).
 


### PR DESCRIPTION
### Motivation
- Ensure users check for potential routing congestion immediately after placement so routing effort can be focused on problematic areas before running the autorouter or manual routing.

### Description
- Added a new step to `CLI.md` instructing to run `tsci check routing-difficulty [file]` after placement snapshots and before `tsci build`.
- Updated `WORKFLOW.md` to recommend running `tsci check routing-difficulty` after placement as part of the iterate-with-build loop.
- Updated `SKILL.md` so the skill's build-and-iterate guidance also includes running `tsci check routing-difficulty` after placement.

### Testing
- Searched the docs for the new guidance with `rg -n "routing-difficulty|potential areas of congestion|identify potential congestion" CLI.md WORKFLOW.md SKILL.md` and confirmed the inserted lines are present.
- Attempted formatting with `bun run format` but skipped because `package.json` was not found in the repository.
- Attempted TypeScript typecheck with `bunx tsc --noEmit` but skipped because no TypeScript project files (`tsconfig.json`/`package.json`) were present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc990c3aec832eae53d5b3945284c0)