### PR TITLE
Enhance documentation for `sel` net selectors with usage examples and type safety guidelines

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -40,7 +40,7 @@ When this Skill is active:
   - PCB: `pcbX`, `pcbY`, `pcbRotation`, `layer`
   - Schematic: `schX`, `schY`, `schRotation`, `schOrientation`
 - Use `<trace />` for connectivity; prefer net connections (`net.GND`, `net.VCC`, etc.) for power/ground.
-- When using `sel` for nets, use `sel.net.GND`-style property access only for common built-in nets. For arbitrary custom nets, prefer `sel.net().USB_DP_RAW` for one-offs or `const nets = sel.net<"USB_DP_RAW" | "USB_DM_RAW">()` for reusable typed custom nets.
+- When using `sel` for nets, reserve `sel.net.GND`-style property access for common built-in nets. For custom nets, define and reuse a shared typed selector map in `nets.ts` such as `export const nets = sel.net<"MOTOR_POS" | "MOTOR_NEG" | ... >()`.
 
 5) Build and iterate
 - Run `tsci check netlist` before `tsci check placement` and `tsci build` to catch connectivity issues early.

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,6 +40,7 @@ When this Skill is active:
   - PCB: `pcbX`, `pcbY`, `pcbRotation`, `layer`
   - Schematic: `schX`, `schY`, `schRotation`, `schOrientation`
 - Use `<trace />` for connectivity; prefer net connections (`net.GND`, `net.VCC`, etc.) for power/ground.
+- When using `sel` for nets, use `sel.net.GND`-style property access only for common built-in nets. For arbitrary custom nets, prefer `sel.net().USB_DP_RAW` for one-offs or `const nets = sel.net<"USB_DP_RAW" | "USB_DM_RAW">()` for reusable typed custom nets.
 
 5) Build and iterate
 - Run `tsci check netlist` before `tsci check placement` and `tsci build` to catch connectivity issues early.

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,7 +40,7 @@ When this Skill is active:
   - PCB: `pcbX`, `pcbY`, `pcbRotation`, `layer`
   - Schematic: `schX`, `schY`, `schRotation`, `schOrientation`
 - Use `<trace />` for connectivity; prefer net connections (`net.GND`, `net.VCC`, etc.) for power/ground.
-- When using `sel` for nets, reserve `sel.net.GND`-style property access for common built-in nets. For custom nets, define and reuse a shared typed selector map in `nets.ts` such as `export const nets = sel.net<"MOTOR_POS" | "MOTOR_NEG" | ... >()`.
+- Use `sel` for net references as a typed alternative to net strings like "net.GND". You can create a `nets.ts` file with custom nets, just `export const nets = sel.net<"NET1" | "NET2">()` then use `nets.NET1` as the net reference.
 
 5) Build and iterate
 - Run `tsci check netlist` before `tsci check placement` and `tsci build` to catch connectivity issues early.

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -162,22 +162,15 @@ sel.net.GND
 sel.net.V3_3
 ```
 
-For arbitrary custom nets, call `sel.net()` first:
+If you want reusable typed custom nets, define them once and import them where needed:
 
 ```tsx
-sel.net().USB_DP_RAW
-sel.net().USB_DM_RAW
-```
-
-If you want reusable typed custom nets, create a typed selector map once:
-
-```tsx
+// nets.ts
 import { sel } from "tscircuit"
 
-const nets = sel.net<"USB_DP_RAW" | "USB_DM_RAW">()
+export const nets = sel.net<"MOTOR1_POS" | "MOTOR2_POS" | ... >()
 
-nets.USB_DP_RAW
-nets.USB_DM_RAW
+nets.MOTOR1_POS // "net.MOTOR1_POS"
 ```
 
 ## 9) Grouping for PCB layout

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -145,7 +145,42 @@ Useful trace props (optional)
 - `width` / `thickness`
 - `minLength` / `maxLength`
 
-## 8) Grouping for PCB layout
+## 8) `sel` net selectors
+
+Use `sel` when you want selector expressions with better type safety than raw strings:
+
+```tsx
+import { sel } from "tscircuit"
+
+<trace from={sel.U1.VCC} to={sel.net.GND} />
+```
+
+For common built-in nets, property access is fine:
+
+```tsx
+sel.net.GND
+sel.net.V3_3
+```
+
+For arbitrary custom nets, call `sel.net()` first:
+
+```tsx
+sel.net().USB_DP_RAW
+sel.net().USB_DM_RAW
+```
+
+If you want reusable typed custom nets, create a typed selector map once:
+
+```tsx
+import { sel } from "tscircuit"
+
+const nets = sel.net<"USB_DP_RAW" | "USB_DM_RAW">()
+
+nets.USB_DP_RAW
+nets.USB_DM_RAW
+```
+
+## 9) Grouping for PCB layout
 
 Use `<group />` like a container to move/layout parts together.
 
@@ -159,7 +194,7 @@ Use `<group />` like a container to move/layout parts together.
 </board>
 ```
 
-## 9) Schematic pin arrangement
+## 10) Schematic pin arrangement
 
 Control how pins appear on the schematic symbol with `schPinArrangement`:
 
@@ -194,7 +229,7 @@ Available sides: `leftSide`, `rightSide`, `topSide`, `bottomSide`
 - Left/right sides use `direction: "top-to-bottom"` or `"bottom-to-top"`
 - Top/bottom sides use `direction: "left-to-right"` or `"right-to-left"`
 
-## 10) Manufacturing helpers
+## 11) Manufacturing helpers
 
 For turnkey assembly you will often want:
 - `supplierPartNumbers` (pin a specific supplier SKU/part number)

--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -152,23 +152,17 @@ Use `sel` when you want selector expressions with better type safety than raw st
 ```tsx
 import { sel } from "tscircuit"
 
+// sel has common net names built-in (uncommon nets will fail type check)
 <trace from={sel.U1.VCC} to={sel.net.GND} />
 ```
 
-For common built-in nets, property access is fine:
-
-```tsx
-sel.net.GND
-sel.net.V3_3
-```
-
-If you want reusable typed custom nets, define them once and import them where needed:
+Best practice: For typed custom nets specific to your project, define them in `nets.ts` and import where needed:
 
 ```tsx
 // nets.ts
 import { sel } from "tscircuit"
 
-export const nets = sel.net<"MOTOR1_POS" | "MOTOR2_POS" | ... >()
+export const nets = sel.net<"MOTOR1_POS" | "MOTOR2_POS">()
 
 nets.MOTOR1_POS // "net.MOTOR1_POS"
 ```


### PR DESCRIPTION
 ## Summary

  This PR improves the tscircuit docs around sel net selectors so AI-generated and human-written code are more likely to use the type-safe pattern for custom nets.

  It adds explicit guidance that sel.net.GND-style property access is for common built-in nets, while custom nets should be defined through a shared typed selector map.

  ## Problem

  The existing docs did not clearly separate built-in net access from custom net access, which made it easier for generated code to drift toward unsupported or non-type-safe custom net patterns.

  That ambiguity can lead to TypeScript errors when custom nets are accessed as if they were part of the built-in sel.net.* set.

  ## Changes

  - Added a new sel net selectors section to SYNTAX.md
  - Documented sel.net.GND and similar property access as the pattern for common built-in nets
  - Added a typed custom-net example using a shared nets.ts selector map:
    export const nets = sel.net<"MOTOR1_POS" | "MOTOR2_POS" | ... >()
  - Added matching guidance to SKILL.md so the skill prompt and syntax primer are aligned
  - Renumbered the later SYNTAX.md sections after inserting the new selector guidance

  ## Impact

  This should reduce a common docs-driven codegen mistake around custom net selectors and make the recommended custom-net workflow clearer and more type-safe.

https://github.com/tscircuit/tscircuit/issues/2815