### PR TITLE
Document npx skills install, make README agent-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
-# tscircuit Claude Skill
+# tscircuit Agent Skill
 
-This folder is intended to be used as a Claude Code Skill.
+This folder is intended to be used as an agent Skill.
 
 Install as:
 
-- Personal Skill (for you):
-  - `~/.claude/skills/tscircuit/`
-
-- Project Skill (shared in repo):
-  - `.claude/skills/tscircuit/`
+- `npx skills add tscircuit/skill`
 
 The canonical entrypoint is `SKILL.md`.
 


### PR DESCRIPTION
Adds `npx skills add tscircuit/skill` install instructions and makes the README agent-agnostic instead of Claude-specific.