### PR TITLE
Document `tsci simulate analog` SPICE simulation command in CLI primer

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -170,7 +170,36 @@ tsci snapshot --pcb-only
 tsci snapshot --test
 ```
 
-9) Auth / publish
+9) Simulate (SPICE analysis)
+- `tsci simulate analog <file>` runs an analog SPICE simulation (`analog` is currently the only `simulate` subcommand).
+- Accepts a tscircuit `.tsx` source or a circuit JSON file.
+- Builds the circuit JSON, converts it to a SPICE netlist, runs ngspice, and prints the results as a table.
+- The circuit needs at least one source (e.g. `<voltagesource>`) for a meaningful transient run.
+
+Flags:
+- `--disable-parts-engine` – Disable the parts engine (skip part-number resolution/lookups).
+
+Output columns:
+- `Index` – sample number
+- `time` – simulation time (transient analysis)
+- `v(...)` – node voltage probes
+- `i(...)` – source/branch current probes
+
+ngspice prints diagnostic info first, then the table. Values use exponential notation, e.g.:
+```text
+Index  time         v(n1)        v(n2)        i(vsimulation_voltage_source_0)
+0      2.000000e-6  5.000000e+0  9.998000e-4  -4.999000e-3
+1      4.000000e-6  5.000000e+0  1.999400e-3  -4.998001e-3
+2      8.000000e-6  5.000000e+0  3.998201e-3  -4.996002e-3
+...
+```
+
+Example:
+```bash
+tsci simulate analog index.circuit.tsx
+```
+
+10) Auth / publish
 - `tsci login` (browser-based)
 - `tsci push` (publish package)
 - `tsci auth print-token`

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tscircuit
-description: Build, modify, and debug tscircuit (React/TypeScript) PCB designs. Use when working with tsci CLI (init/dev/search/add/import/build/export/snapshot/push), choosing footprints, placing parts, wiring nets/traces, or preparing fabrication outputs (Gerbers/BOM/PnP).
+description: Build, modify, and debug tscircuit (React/TypeScript) PCB designs. Use when working with tsci CLI (init/dev/search/add/import/build/export/simulate/snapshot/push), choosing footprints, placing parts, wiring nets/traces, or preparing fabrication outputs (Gerbers/BOM/PnP).
 allowed-tools: Read, Write, Grep, Glob, Bash
 ---
 


### PR DESCRIPTION
## What

Adds a dedicated section to `CLI.md` documenting `tsci simulate`, which was previously undocumented in the skill primer.

Covers:
- `tsci simulate analog <file>` — runs an analog SPICE simulation; notes that `analog` is currently the only `simulate` subcommand.
- Accepted inputs: a tscircuit `.tsx` source or a circuit JSON file.
- The pipeline: build circuit JSON → SPICE netlist → ngspice → results table.
- The `--disable-parts-engine` flag.
- Output column reference: `Index`, `time`, `v(...)` node-voltage probes, `i(...)` current probes, in exponential notation.

## Example output

The sample table is real, not hand-written — it was captured by running `tsci simulate analog` against an RC test circuit, so the column names and formatting match actual CLI output. The section also notes that ngspice prints diagnostic info ahead of the table.

## Why

`simulate` is exposed by the CLI but had no entry in the primer, so agents and users had no reference for the command, its input formats, its flag, or how to read the output table.
