### PR TITLE
Document tsci snapshot view flags (--schematic-only, --simulation-only, --layer, camera presets)

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -155,8 +155,19 @@ Common formats
 - `tsci snapshot` generates visual outputs (schematic/PCB, optionally 3D) and writes/overwrites snapshots by default.
 - Use these visuals to inspect placement, orientation, and overall circuit understanding during iteration.
 - `tsci snapshot --test` switches to regression-test mode: it fails on visual diffs and does **not** overwrite snapshots.
+
+Snapshot types (pick which views to generate):
 - `tsci snapshot --pcb-only` generates only PCB visuals, which is especially useful for placement-focused iteration.
+- `tsci snapshot --schematic-only` generates only the schematic view.
+- `tsci snapshot --simulation-only` generates only simulation snapshots.
 - `tsci snapshot --3d` includes 3D snapshots in the output.
+- `tsci snapshot --layer top` (or `bottom`) renders a single PCB layer (implies `--pcb-only`).
+
+Useful options:
+- `--camera-preset <preset>` sets the 3D camera angle (implies `--3d`); presets include `top-down`, `top-down-ortho`, `top-left`, `top-right`, `left-sideview`, `right-sideview`, `front`, `top-center-angled`.
+- `--show-courtyards` overlays courtyard outlines in PCB snapshots.
+- `-u, --update` / `--force-update` write (or force-write) snapshots to disk; `--disable-parts-engine` skips the parts engine.
+- `path` accepts a file, directory, or glob (e.g. `examples/**/*.tsx`); `--concurrency <n>` snapshots multiple files in parallel.
 
 Recommended pattern:
 ```bash
@@ -165,6 +176,10 @@ tsci snapshot
 
 # During placement-heavy iterations: focus only on PCB output
 tsci snapshot --pcb-only
+
+# Generate only one view when that's all you need
+tsci snapshot --schematic-only
+tsci snapshot --simulation-only
 
 # In CI/regression checks: detect unexpected visual changes without overwriting
 tsci snapshot --test

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -84,6 +84,7 @@
 - Use `tsci build` in CI or before sharing.
 - Use `tsci snapshot` to generate visuals that help with placement analysis and quick circuit understanding.
 - Use `tsci snapshot --pcb-only` when you want a fast, placement-focused PCB view without schematic snapshots.
+- Use `tsci snapshot --schematic-only` or `--simulation-only` to render just the schematic or simulation view; add `--3d` (optionally with `--camera-preset`) for a 3D preview.
 - Use `tsci snapshot --test` in CI/regression checks to prevent overwriting snapshots and catch unexpected visual diffs.
 
 ## 9) Export what you need


### PR DESCRIPTION
## What

Expands the `tsci snapshot` section of the skill docs to cover the snapshot options that were previously undocumented. Until now the CLI reference only mentioned `--pcb-only`, `--3d`, and `--test`, so the other views and flags were undiscoverable.

### Added to CLI.md
- **Snapshot types:** `--schematic-only`, `--simulation-only`, and `--layer top|bottom` alongside the existing `--pcb-only` / `--3d`.
- **Useful options:** `--camera-preset <preset>` (with the full preset list), `--show-courtyards`, `-u/--update` & `--force-update`, `--disable-parts-engine`, the `path` glob argument, and `--concurrency <n>`.
- Updated the lead description and the recommended-pattern snippet to surface the single-view commands.

### Added to WORKFLOW.md
- A note pointing to `--schematic-only` / `--simulation-only` and the `--3d` + `--camera-preset` 3D preview.

## Why

These flags are all real (`tsci snapshot --help`), but absent from the docs the agent defaults to full snapshots even when one view is wanted. Documenting them lets it pick the cheapest correct view (e.g. `--schematic-only` during wiring, `--layer` for a single copper layer) and use 3D camera presets deliberately.

## Verification

Every flag listed was cross-checked against `tsci snapshot --help` on the installed CLI; no behavior changes, docs only.
