### PR TITLE
Document autorouter stage debugging

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -142,6 +142,18 @@ Notes
 Useful flags
 - `--all-images` (emit PCB/schematic/3D renders into `dist/`)
 
+Autorouter stage debugging
+- `tsci build [file] --autorouter-debug` logs each autorouting stage and writes
+  cumulative images to `dist/autorouter-debug/`.
+- `placement-unrouted.png` shows the PCB before routing starts.
+- `phase-N-routed.png` shows cumulative routing after zero-indexed stage `N`.
+  Fanout and its downstream router are separate stages.
+- Use `--autorouter-debug-dir <path>` to choose another artifact directory.
+- Add `--autorouter-dump-srj all` for every stage's
+  `phase-N.input.simple-route.json` and `phase-N.output.traces.json`.
+- Use `--autorouter-dump-srj failed` for only failed-stage data, or
+  `--autorouter-dump-srj phase:N` for one stage.
+
 DRC (Design Rule Check)
 - DRC errors are often reported but can frequently be ignored during development.
 - Focus on getting the circuit correct first; DRC violations can be addressed later when preparing for manufacturing.

--- a/SKILL.md
+++ b/SKILL.md
@@ -53,6 +53,11 @@ When this Skill is active:
 - Run `tsci build --pcb-png [file]` to inspect placement before checking routing.
 - Run `tsci check routing-difficulty` after placement to identify potential areas of congestion.
 - Run `tsci build` to compile and validate the circuit.
+- When routing looks suspicious, run
+  `tsci build [file] --autorouter-debug --autorouter-debug-dir dist/autorouter-debug`
+  and inspect `placement-unrouted.png` plus each cumulative
+  `phase-N-routed.png`. Add `--autorouter-dump-srj all` when the
+  SimpleRouteJson input and output for every stage is also needed.
 - After routing, run `tsci check shorts [file]` to detect unintended shorts between separate PCB copper groups. Omit `[file]` to use the project entrypoint; a prebuilt `*.circuit.json` file is also accepted.
 - A detected short makes `tsci check shorts` exit nonzero. Inspect `checks/check-shorts/bitmap.png` and `checks/check-shorts/pcb.svg`, fix the implicated copper, then rerun the check. Do not dismiss this failure as a generic DRC warning.
 - The default check analyzes Gerber-derived copper on both layers. Use `--mode pcb` for PCB geometry, `--layer top` or `--layer bottom` to narrow the scope, and `--pixels-per-mm <number>` only when a different bitmap resolution is needed.


### PR DESCRIPTION
## Summary

- add the autorouter stage-image workflow to the main tscircuit skill
- document `placement-unrouted.png` and cumulative `phase-N-routed.png` files
- document debug-directory selection and SimpleRouteJson dump modes

## Why

`tsci build --autorouter-debug` is useful for distinguishing fanout behavior
from the downstream autorouter, but the skill did not tell agents that the flag
generates visual artifacts or how to capture per-stage SRJ data.

## Validation

- `git diff --check`
