### PR TITLE
Document DigiKey and Mouser search

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -28,9 +28,14 @@ Typical output includes:
 
 Search flags:
 - `--jlcpcb` (or `--lcsc`) – Search JLCPCB/LCSC components by name or part number
+- `--digikey` – Search DigiKey components and cached stock
+- `--mouser` – Search Mouser components and cached stock
 - `--kicad` – Search KiCad footprint library
 - `--tscircuit` – Search tscircuit registry packages
 - `--json` – Return machine-readable JSON output instead of plain text
+
+JLCPCB is searched when no source flag is supplied. Source flags can be
+combined to search more than one provider in a single command.
 
 Examples:
 ```bash
@@ -44,6 +49,17 @@ tsci search --jlcpcb "C14877"
 # Search JLCPCB for Micro-USB connectors
 tsci search --jlcpcb "micro usb connector"
 
+# Search DigiKey inventory
+tsci search --digikey "10k 0603 resistor"
+# Output: RC0603FR-0710KL (311-10.0KHRCT-ND) - ... (stock: ...)
+
+# Search Mouser inventory
+tsci search --mouser "10k 0603 resistor"
+# Output: RC0603FR-0710KL (603-RC0603FR-0710KL) - ... (stock: ...)
+
+# Compare both distributor sources
+tsci search --digikey --mouser "STM32F4 microcontroller"
+
 # Search KiCad footprints
 tsci search --kicad "QFP-32"
 # Output: kicad:Package_QFP/LQFP-32_5x5mm_P0.5mm
@@ -55,26 +71,41 @@ tsci search --kicad "0402"
 tsci search --tscircuit "LED"
 # Output: seveibar/usb-c-flashlight - Stars: 5
 
-# Search without flags (searches all sources)
+# Search without flags (searches JLCPCB)
 tsci search "ESP32"
 
-# Search with JSON output (useful for scripts)
-tsci search --jlcpcb "ATmega328" --json
+# Search both distributors with JSON output (useful for scripts)
+tsci search --digikey --mouser "10k 0603 resistor" --json
 # Example output:
 # {
+#   "query": "10k 0603 resistor",
 #   "results": [
 #     {
-#       "source": "jlcpcb",
-#       "name": "ATMEGA328P-AU",
-#       "part_number": "C14877",
-#       "description": "Microcontroller Unit, 8-bit AVR",
-#       "manufacturer": "Microchip Tech",
-#       "stock": 20226,
-#       "price": "0.735"
+#       "source": "digikey",
+#       "digikey_product_number": "311-10.0KHRCT-ND",
+#       "mfr": "RC0603FR-0710KL",
+#       "manufacturer": "YAGEO",
+#       "package": "0603",
+#       "description": "...",
+#       "stock": 100000
+#     },
+#     {
+#       "source": "mouser",
+#       "mouser_product_number": "603-RC0603FR-0710KL",
+#       "mfr": "RC0603FR-0710KL",
+#       "manufacturer": "YAGEO",
+#       "package": "0603",
+#       "description": "...",
+#       "stock": 100000
 #     }
 #   ]
 # }
 ```
+
+DigiKey and Mouser results are loaded through tscircuit's cached search
+services. Their `stock` and `price` fields are snapshots and can change. These
+flags discover orderable parts; `tsci import` currently imports only from
+JLCPCB or the tscircuit registry.
 
 4) Add existing registry packages to your project
 - `tsci add <author/pkg>`

--- a/SKILL.md
+++ b/SKILL.md
@@ -30,10 +30,12 @@ When this Skill is active:
 
 3) Find and install components
 - Use `tsci search "<query>"` to discover footprints and tscircuit registry packages.
+- Use `tsci search --digikey "<query>"` or `tsci search --mouser "<query>"` when distributor stock and supplier part numbers matter. Both flags can be combined, and `--json` provides machine-readable results.
 - For USB-C receptacles/connectors, prefer builtin syntax with `<connector standard="usb_c" />` instead of importing from JLCPCB.
 - Use one of:
   - `tsci add <author/pkg>` for registry packages (installs `@tsci/*` packages)
   - `tsci import <query>` when you need to import a component from JLCPCB or the registry.
+- DigiKey and Mouser search results are for part discovery; `tsci import` does not directly import from those distributors.
 
 4) Write/modify TSX circuit code
 - Keep circuits as a default-exported function that returns JSX.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -15,14 +15,19 @@
 
 - Use `tsci search` to find:
   - JLCPCB components: `tsci search --jlcpcb "STM32F4"`
+  - DigiKey inventory: `tsci search --digikey "STM32F4"`
+  - Mouser inventory: `tsci search --mouser "STM32F4"`
   - KiCad footprints: `tsci search --kicad "SOIC8"`
   - Registry packages: `tsci search --tscircuit "ESP32"`
+- Combine supplier flags to compare stocked parts, for example
+  `tsci search --digikey --mouser "10k 0603 resistor"`.
 
 ## 4) Add/import parts
 
 - Prefer `tsci add <author/pkg>` when a reusable module exists.
 - Use `tsci import` when you must bring in a specific component (e.g., supplier part).
 - For JLCPCB parts: first search with `tsci search --jlcpcb "<query>"`, then import with `tsci import "<part number>"`.
+- DigiKey and Mouser searches return distributor part numbers, manufacturer part numbers, descriptions, and stock for discovery. They are not direct `tsci import` sources.
 
 ## 5) Define pinLabels and pinAttributes first
 


### PR DESCRIPTION
## Summary

- document `tsci search --digikey` and `tsci search --mouser` in the CLI reference and default workflow
- show how to combine both suppliers and consume unified `--json` output
- explain cached stock semantics and supplier-specific part-number fields
- clarify that unfiltered search defaults to JLCPCB and that DigiKey/Mouser are discovery sources, not direct `tsci import` sources

## Why

The CLI supplier-search integrations need matching agent guidance so generated workflows choose the intended source and do not incorrectly assume distributor results can be imported directly.

Depends on tscircuit/cli#4116 and tscircuit/cli#4119.

## Validation

- `git diff --check`
- manually checked every DigiKey/Mouser command and JSON field against the CLI implementation