### PR TITLE
Document parametric enclosure authoring

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -91,6 +91,7 @@ When this Skill is active:
 ## Builtin Elements
 
 - [`<analogsimulation />`](./elements/analogsimulation.md)
+- [`<assembly.device />`](./elements/assemblydevice.md)
 - [`<battery />`](./elements/battery.md)
 - [`<board />`](./elements/board.md)
 - [`<breakout />`](./elements/breakout.md)
@@ -111,6 +112,8 @@ When this Skill is active:
 - [`<currentsource />`](./elements/currentsource.md)
 - [`<cutout />`](./elements/cutout.md)
 - [`<diode />`](./elements/diode.md)
+- [`<enclosure.cutoutaperture />`](./elements/enclosurecutoutaperture.md)
+- [`<enclosure.fdm.box />`](./elements/enclosurefdmbox.md)
 - [`<fabricationnotedimension />`](./elements/fabricationnotedimension.md)
 - [`<fabricationnotepath />`](./elements/fabricationnotepath.md)
 - [`<fabricationnoterect />`](./elements/fabricationnoterect.md)

--- a/elements/assemblydevice.md
+++ b/elements/assemblydevice.md
@@ -1,0 +1,32 @@
+# `<assembly.device />`
+
+The assembled product: a board together with the mechanical parts built around
+it. It is the root a board and its enclosure share, so the enclosure has
+something to reference.
+
+## Example
+
+```tsx
+import { assembly, enclosure } from "tscircuit"
+
+export default () => (
+  <assembly.device name="widget">
+    <board name="B1" width="52mm" height="36mm">
+      {/* parts */}
+    </board>
+    <enclosure.fdm.box boardRef=".B1" />
+  </assembly.device>
+)
+```
+
+Use it when a design has anything beyond the bare PCB. A board on its own does
+not need one.
+
+## Props
+
+Commonly used: `name`
+
+## References
+
+- Props: [AssemblyDeviceProps](https://github.com/tscircuit/props/blob/main/lib/assembly/device.ts)
+- See also: [`<enclosure.fdm.box />`](./enclosurefdmbox.md), [`<board />`](./board.md)

--- a/elements/cadmodel.md
+++ b/elements/cadmodel.md
@@ -20,9 +20,62 @@ export default () => (
 )
 ```
 
+## Model orientation
+
+A CAD asset has its own fixed orientation, and the part's
+`insertionDirection` must be declared **to match the model** -- it says which way
+the part's mouth points in the footprint's own frame, not which wall or edge you
+want the part on. Declare it wrongly and the model renders one way while checks
+and enclosure openings are computed for another, with nothing reporting an error.
+
+Most EasyEDA side-entry assets face **-X** natively, hence
+`insertionDirection="from_left"`. Where an asset does not match its footprint,
+turn the model rather than mis-declaring the direction:
+
+- `pcbRotationOffset` -- rotate the model about the board normal, relative to
+  its footprint (a quarter turn is the common case).
+- `modelBoardNormalDirection` -- name the model axis that leaves the board, when
+  it is not the default `z+`.
+
+To place a part on a different edge, rotate the whole part with `pcbRotation`
+and let the transform carry the direction round.
+
+Working references for real assets live in
+[`core/tests/enclosure/prefab-board/parts/`](https://github.com/tscircuit/core/tree/main/tests/enclosure/prefab-board/parts),
+each pairing a model URL with the `insertionDirection` and offsets it needs.
+
+## Measured bounds
+
+`size` is the model's extent, but it does not say where that box sits relative to
+the model's origin, and the box is generally not centred on it. So `size` alone
+cannot say how much of a part stands above the board -- which is what an
+enclosure needs in order to clear it.
+
+`modelBounds` supplies the missing term. It is the model's axis-aligned extent in
+its **own** coordinate frame, the same frame as `modelOriginPosition`, which is
+the point of the model placed on the board surface:
+
+```tsx
+cadModel={{
+  objUrl: "https://modelcdn.tscircuit.com/easyeda_models/download?uuid=...",
+  modelOriginPosition: { x: 7.27506, y: 0, z: -2.550001 },
+  // Measured from the asset: 5.30mm of body above the board, 0.55mm of pin below.
+  modelBounds: {
+    min: { x: -1.5, y: -4, z: -3.1 },
+    max: { x: 12.6, y: 4, z: 2.75 },
+  },
+  size: { x: 14.1, y: 8, z: 5.84998 },
+}}
+```
+
+Above-board reach is then `max[normal] - modelOriginPosition[normal]`, with
+`modelBoardNormalDirection` naming the axis (default `z+`). Whatever generates a
+part file already measures this to produce `size`, so it is cheap to include --
+and without it an enclosure falls back to guessing from the opening's own size.
+
 ## Props
 
-Commonly used: `modelUrl`, `stepUrl`, `pcbX`, `pcbY`, `pcbLeftEdgeX`, `pcbRightEdgeX`, `pcbTopEdgeY`, `pcbBottomEdgeY`
+Commonly used: `modelUrl`, `stepUrl`, `size`, `modelBounds`, `modelOriginPosition`, `pcbRotationOffset`, `pcbX`, `pcbY`, `pcbLeftEdgeX`, `pcbRightEdgeX`, `pcbTopEdgeY`, `pcbBottomEdgeY`
 
 ## References
 

--- a/elements/connector.md
+++ b/elements/connector.md
@@ -112,7 +112,33 @@ For vertical-entry connectors, such as a battery connector inserted from above, 
 />
 ```
 
-Other insertion directions are `from_left`, `from_right`, `from_front`, and `from_back`.
+Other insertion directions are `from_left` (-X), `from_right` (+X), `from_top`
+(+Y), `from_bottom` (-Y) and `from_below` (-Z).
+
+`insertionDirection` describes the part **in its own footprint frame** -- which
+way the cable or mating part comes from as the footprint is drawn. It is not the
+board edge you want the part on. Placement supplies the rest: core rotates the
+declared direction by the component's `pcbRotation` and mirrors it for the
+mounting layer, then records the result on `pcb_component.insertion_direction`.
+
+So to move a part to a different edge, rotate the part and leave the declared
+direction alone:
+
+```tsx
+{/* Declared -X; rotating 180 degrees carries it round to +X. */}
+<connector name="J2" pcbX={19} pcbY={6} pcbRotation={180}
+  footprint={<footprint insertionDirection="from_left">{/* pads */}</footprint>}
+/>
+```
+
+The direction must match the part's CAD model, if it has one -- see
+[`<cadmodel />`](./cadmodel.md#model-orientation).
+
+`from_front` and `from_back` are deprecated spellings of `from_top` and
+`from_bottom`. They still parse, but are never emitted; prefer the canonical
+names. They were retired because they read as though they described a 3D
+viewport rather than the board as drawn in the 2D PCB view, and different
+packages had resolved that ambiguity in opposite directions.
 
 ## Props
 

--- a/elements/enclosurecutoutaperture.md
+++ b/elements/enclosurecutoutaperture.md
@@ -19,11 +19,23 @@ gets the hole for free.
 
 ## Which face it pierces
 
-You do not choose the face. It comes from the part's transformed
-`insertionDirection`, which already accounts for the component's rotation and
-mounting layer, so it names the edge the part is actually reached from. Rotate
-the part to move its opening to another wall; do not re-declare the direction.
-See [`<connector />`](./connector.md).
+You do not choose the face on the aperture. It comes from a direction declared on
+the part's `<footprint />`, transformed for the component's rotation and mounting
+layer, so it names the face the part is actually reached from. Rotate the part to
+move its opening to another wall; do not re-declare the direction.
+
+Which direction, in order:
+
+1. `cutoutApertureDirection` -- where the part's opening faces;
+2. `insertionDirection` -- where a cable or mating part attaches, used when the
+   part declares no aperture direction;
+3. failing both, the nearest reachable board edge, which is a guess.
+
+Most parts need only `insertionDirection`: a cable arrives through the opening it
+needs, so the two directions coincide. Declare `cutoutApertureDirection` when
+they differ -- a side-actuated switch is *installed* from above and *actuated*
+from the side, so its opening pierces a wall while nothing is ever inserted into
+it. See [`<footprint />`](./footprint.md#insertion-and-aperture-directions).
 
 `from_above` and `from_below` exit through the lid and the floor instead of a
 wall. Which one is carried by the direction itself: a layer flip is a 180 degree

--- a/elements/enclosurecutoutaperture.md
+++ b/elements/enclosurecutoutaperture.md
@@ -19,10 +19,11 @@ gets the hole for free.
 
 ## Which face it pierces
 
-You do not choose the face on the aperture. It comes from a direction declared on
-the part's `<footprint />`, transformed for the component's rotation and mounting
-layer, so it names the face the part is actually reached from. Rotate the part to
-move its opening to another wall; do not re-declare the direction.
+You do not choose the face on the aperture. A direction declared on the part's
+`<footprint />` is transformed with the component and defines a continuous axis.
+A lid/floor direction selects that horizontal face; a side direction cuts the
+first wall the axis physically reaches. Rotate or move the part to move its
+opening; do not re-declare the direction.
 
 Which direction, in order:
 
@@ -42,20 +43,25 @@ wall. Which one is carried by the direction itself: a layer flip is a 180 degree
 rotation about the board's Y axis, so a part authored `from_above` reports
 `from_below` once mounted on the bottom layer.
 
-## Dimensions are in the face's frame
+## The aperture axis belongs to the part
 
-`width`, `height` and `depth` are measured in the frame of the face the opening
-pierces, not in board axes. The face fixes which axes they mean:
+`cutoutApertureDirection` (or the `insertionDirection` fallback) defines the
+primary aperture axis in the footprint's frame. It rotates and moves with the
+component. For a side opening, the enclosure casts that axis from the component
+centre and cuts the first wall it reaches; the wall can therefore change near a
+corner based on both position and rotation, not at a fixed 45 degrees.
 
-| Face | `width` | `height` | `depth` |
-| --- | --- | --- | --- |
-| `x_pos`, `x_neg` | Y | Z | X |
-| `y_pos`, `y_neg` | X | Z | Y |
-| `z_pos`, `z_neg` | part-local | part-local | Z |
+`width`, `height` and `depth` describe the cutting tool around that axis:
 
-So on any side wall `height` is the vertical dimension and `width` runs along the
-wall. On the lid and the floor the pair follows the part's own rotation, so a
-rotated rectangular opening stays aligned with the part it serves.
+- on a side opening, `height` is vertical, `width` is perpendicular to the axis
+  in the board plane, and `depth` follows the axis inboard;
+- on the lid or floor, `width` and `height` rotate with the footprint and `depth`
+  is vertical; and
+- a circle uses `radius` for its profile.
+
+An oblique circular tool naturally makes an elliptical intersection with the
+wall. The solver lengthens the tool enough to cross the wall without changing
+the authored component-relative depth.
 
 `depth` is how far the cut is projected inboard, so nothing behind the face --
 the lid lip today, mounting bosses later -- is left obstructing the part. It is
@@ -84,11 +90,10 @@ cable jacket fatter than its connector needs.
 ## Props
 
 Commonly used: `shape` (`rect` | `pill` | `circle`), `width`, `height`, `radius`,
-`margin`, `depth`, `widthDimensionOffset`, `heightDimensionOffset`, `boardSide`
+`margin`, `depth`, `widthDimensionOffset`, `heightDimensionOffset`
 
-`margin` is extra clearance applied on every edge. `boardSide` names the PCB
-layer the part is mounted on -- a Z-side concept, so it stays `"top"`/`"bottom"`
-rather than a face name.
+`margin` is extra clearance applied on every edge. The mounting side is not an
+aperture prop; it is derived from the owning component's `layer`.
 
 ## References
 

--- a/elements/enclosurecutoutaperture.md
+++ b/elements/enclosurecutoutaperture.md
@@ -1,0 +1,85 @@
+# `<enclosure.cutoutaperture />`
+
+An opening a part needs in the enclosure around it. Nest it inside the component
+that needs it, so the part carries its own opening and any board using that part
+gets the hole for free.
+
+## Example
+
+```tsx
+<connector
+  name="J1"
+  pcbX={0}
+  pcbY={-15}
+  footprint={<footprint insertionDirection="from_bottom">{/* pads */}</footprint>}
+>
+  <enclosure.cutoutaperture shape="pill" width="10mm" height="4mm" />
+</connector>
+```
+
+## Which face it pierces
+
+You do not choose the face. It comes from the part's transformed
+`insertionDirection`, which already accounts for the component's rotation and
+mounting layer, so it names the edge the part is actually reached from. Rotate
+the part to move its opening to another wall; do not re-declare the direction.
+See [`<connector />`](./connector.md).
+
+`from_above` and `from_below` exit through the lid and the floor instead of a
+wall. Which one is carried by the direction itself: a layer flip is a 180 degree
+rotation about the board's Y axis, so a part authored `from_above` reports
+`from_below` once mounted on the bottom layer.
+
+## Dimensions are in the face's frame
+
+`width`, `height` and `depth` are measured in the frame of the face the opening
+pierces, not in board axes. The face fixes which axes they mean:
+
+| Face | `width` | `height` | `depth` |
+| --- | --- | --- | --- |
+| `x_pos`, `x_neg` | Y | Z | X |
+| `y_pos`, `y_neg` | X | Z | Y |
+| `z_pos`, `z_neg` | part-local | part-local | Z |
+
+So on any side wall `height` is the vertical dimension and `width` runs along the
+wall. On the lid and the floor the pair follows the part's own rotation, so a
+rotated rectangular opening stays aligned with the part it serves.
+
+`depth` is how far the cut is projected inboard, so nothing behind the face --
+the lid lip today, mounting bosses later -- is left obstructing the part. It is
+cut as authored and never capped, so a depth greater than the space behind the
+face reaches the shell on the far side and cuts that too. Usually you can leave
+it out: the depth is otherwise derived from the part's own CAD body.
+
+## Placing it on the face
+
+`widthDimensionOffset` and `heightDimensionOffset` move the opening's centre
+across the face, along those same two axes. Both may be negative.
+
+Zero means *wherever the part puts it*, which is usually right:
+
+- **Side faces** centre the opening on the part's body above the board, taken
+  from the model's measured bounds (see [`<cadmodel />`](./cadmodel.md#measured-bounds)).
+  A part with no measured bounds falls back to half the opening's own height,
+  which rests its lower edge on the mounting surface.
+- **Lid and floor** centre on the part's own position.
+
+`heightDimensionOffset` runs *outward* from the mounting surface on a side face,
+so the same authored number is correct whichever side of the board the part sits
+on. A negative value pulls the opening back toward and past the board -- what a
+cable jacket fatter than its connector needs.
+
+## Props
+
+Commonly used: `shape` (`rect` | `pill` | `circle`), `width`, `height`, `radius`,
+`margin`, `depth`, `widthDimensionOffset`, `heightDimensionOffset`, `boardSide`
+
+`margin` is extra clearance applied on every edge. `boardSide` names the PCB
+layer the part is mounted on -- a Z-side concept, so it stays `"top"`/`"bottom"`
+rather than a face name.
+
+## References
+
+- Props: [EnclosureCutoutApertureProps](https://github.com/tscircuit/props/blob/main/lib/enclosure/cutout-aperture.ts)
+- Solver: [@tscircuit/create-fdm-enclosure](https://github.com/tscircuit/create-fdm-enclosure)
+- See also: [`<enclosure.fdm.box />`](./enclosurefdmbox.md)

--- a/elements/enclosurefdmbox.md
+++ b/elements/enclosurefdmbox.md
@@ -1,0 +1,50 @@
+# `<enclosure.fdm.box />`
+
+Generates a two-part 3D-printable enclosure around a board: a base and a lid with
+a friction-fit lip, sized from the board plus clearances, with an opening cut for
+every aperture the enclosed parts declare.
+
+Place it as a sibling of the board, inside an
+[`<assembly.device />`](./assemblydevice.md), and point it at the board:
+
+## Example
+
+```tsx
+import { assembly, enclosure } from "tscircuit"
+
+export default () => (
+  <assembly.device name="widget">
+    <board name="B1" width="52mm" height="36mm">
+      {/* parts, some carrying <enclosure.cutoutaperture /> */}
+    </board>
+    <enclosure.fdm.box boardRef=".B1" showAsTranslucentModel />
+  </assembly.device>
+)
+```
+
+Every dimension is optional. Width, height and depth are inferred from the board
+and its parts unless given -- and the inferred depth grows, when needed, until
+the lid and its lip clear every side-wall opening.
+
+## Seeing inside it
+
+`showAsTranslucentModel` renders the box translucent so the board and its parts
+stay visible. It is presentation only: the geometry, and anything exported from
+it, is identical either way. Turn it on while placing parts, since an opaque box
+hides exactly the thing you are checking the openings against.
+
+## Props
+
+Commonly used: `boardRef`, `showAsTranslucentModel`, `width`, `height`, `depth`,
+`wallThickness`, `floorThickness`, `lidThickness`, `standoffHeight`,
+`boardClearance`, `topHeadroom`, `lidLipDepth`, `disableCutouts`
+
+`topHeadroom` measures clearance above the board's tallest part, not the box
+interior, so setting it explicitly is the lever on total height. Set it and
+apertures stop growing the box.
+
+## References
+
+- Props: [EnclosureFdmBoxProps](https://github.com/tscircuit/props/blob/main/lib/enclosure/fdm/box.ts)
+- Solver: [@tscircuit/create-fdm-enclosure](https://github.com/tscircuit/create-fdm-enclosure)
+- See also: [`<enclosure.cutoutaperture />`](./enclosurecutoutaperture.md), [`<assembly.device />`](./assemblydevice.md)

--- a/elements/enclosurefdmbox.md
+++ b/elements/enclosurefdmbox.md
@@ -43,9 +43,11 @@ Commonly used: `boardRef`, `width`, `height`, `depth`,
 `wallThickness`, `floorThickness`, `lidThickness`, `standoffHeight`,
 `boardClearance`, `topHeadroom`, `lidLipDepth`, `disableCutouts`
 
-`topHeadroom` measures clearance above the board's tallest part, not the box
-interior, so setting it explicitly is the lever on total height. Set it and
-apertures stop growing the box.
+`topHeadroom` is the empty distance from the PCB's top surface to the inside of
+the lid -- it is **not** clearance above the tallest component. Omitted, the box
+may grow to clear parts that declare enclosure apertures. Set explicitly, it is
+taken literally and aperture-owning parts stop growing the box; other tall parts
+are not inferred, so check their CAD height yourself.
 
 ## References
 

--- a/elements/enclosurefdmbox.md
+++ b/elements/enclosurefdmbox.md
@@ -33,9 +33,10 @@ and its parts stay visible while you check the openings against them.
 
 How a part is *shown* is a property of looking at it, not of the part, so it is
 not a prop and does not appear in the circuit JSON: the geometry and every
-export are identical either way. In the 3D viewer, each printed part -- base and
-lid -- has its own entry under **Appearance**, cycling see-through -> solid ->
-hidden, so you can take the lid off without losing the base.
+export are identical either way. In the 3D viewer, **Appearance → Enclosure**
+cycles the assembled base and lid together through see-through -> solid ->
+hidden. Independent base/lid controls are deferred until Circuit JSON carries
+an explicit role for each printed part.
 
 ## Props
 

--- a/elements/enclosurefdmbox.md
+++ b/elements/enclosurefdmbox.md
@@ -17,7 +17,7 @@ export default () => (
     <board name="B1" width="52mm" height="36mm">
       {/* parts, some carrying <enclosure.cutoutaperture /> */}
     </board>
-    <enclosure.fdm.box boardRef=".B1" showAsTranslucentModel />
+    <enclosure.fdm.box boardRef=".B1" />
   </assembly.device>
 )
 ```
@@ -28,14 +28,18 @@ the lid and its lip clear every side-wall opening.
 
 ## Seeing inside it
 
-`showAsTranslucentModel` renders the box translucent so the board and its parts
-stay visible. It is presentation only: the geometry, and anything exported from
-it, is identical either way. Turn it on while placing parts, since an opaque box
-hides exactly the thing you are checking the openings against.
+Nothing to author. Enclosure parts render see-through by default, so the board
+and its parts stay visible while you check the openings against them.
+
+How a part is *shown* is a property of looking at it, not of the part, so it is
+not a prop and does not appear in the circuit JSON: the geometry and every
+export are identical either way. In the 3D viewer, each printed part -- base and
+lid -- has its own entry under **Appearance**, cycling see-through -> solid ->
+hidden, so you can take the lid off without losing the base.
 
 ## Props
 
-Commonly used: `boardRef`, `showAsTranslucentModel`, `width`, `height`, `depth`,
+Commonly used: `boardRef`, `width`, `height`, `depth`,
 `wallThickness`, `floorThickness`, `lidThickness`, `standoffHeight`,
 `boardClearance`, `topHeadroom`, `lidLipDepth`, `disableCutouts`
 

--- a/elements/footprint.md
+++ b/elements/footprint.md
@@ -84,9 +84,46 @@ export default () => (
 )
 ```
 
+## Insertion and aperture directions
+
+Two optional props say how the part is physically interacted with. Both are
+authored in the part's **unrotated** frame and are properties of the part, not of
+one board: rotating or flipping the component rotates them with it.
+
+| Prop | Means |
+| --- | --- |
+| `insertionDirection` | the side a cable or mating part attaches from |
+| `cutoutApertureDirection` | the side the part's enclosure opening faces |
+
+Both use the same vocabulary, naming a **side** rather than a motion:
+`from_top` is +Y, `from_bottom` -Y, `from_left` -X, `from_right` +X,
+`from_above` +Z, `from_below` -Z. Cartesian spellings (`from_y_pos`, ...) are
+accepted. A receptacle on the +Y edge is `from_top` because that is the side the
+plug comes from, even though the plug moves in -Y as it seats.
+
+```tsx
+{/* A USB-C receptacle: the cable enters through the opening it needs, so one
+    direction says everything. */}
+<footprint insertionDirection="from_top">{/* pads */}</footprint>
+
+{/* A side-actuated switch: pressed into the board from above, actuated
+    sideways. Both are true, and the opening follows the second one. */}
+<footprint insertionDirection="from_above" cutoutApertureDirection="from_top">
+  {/* pads */}
+</footprint>
+```
+
+Declare `cutoutApertureDirection` only when it differs from
+`insertionDirection`; absent, the opening follows the insertion direction, which
+is right for every connector. Do not reuse `insertionDirection` to steer an
+opening on a part that has nothing inserted into it -- it is read by other tools
+as the mating side, and a switch has none.
+
+These drive [`<enclosure.cutoutaperture />`](./enclosurecutoutaperture.md#which-face-it-pierces).
+
 ## Props
 
-Commonly used: `children`, `originalLayer`, `circuitJson`, `src`, `name`, `footprint`, `connections`
+Commonly used: `children`, `originalLayer`, `circuitJson`, `src`, `name`, `footprint`, `connections`, `insertionDirection`, `cutoutApertureDirection`
 
 ## References
 

--- a/elements/switch.md
+++ b/elements/switch.md
@@ -14,6 +14,20 @@ export default () => (
 
 Commonly used: `type`, `isNormallyClosed`, `spdt`, `spst`, `dpst`, `dpdt`, `simSwitchFrequency`, `simCloseAt`
 
+## Side-actuated switches
+
+A switch whose lever exits the side of its body is *installed* from above and
+*actuated* from the side. Say both on the footprint, or its enclosure opening
+lands in the lid above a lever that points at a wall:
+
+```tsx
+<footprint insertionDirection="from_above" cutoutApertureDirection="from_top">
+  {/* pads; the lever exits the +Y side of the unrotated footprint */}
+</footprint>
+```
+
+See [`<footprint />`](./footprint.md#insertion-and-aperture-directions).
+
 ## References
 
 - Props: [SwitchProps](https://github.com/tscircuit/props#switchprops-switch)


### PR DESCRIPTION
## Summary

- document `assembly.device`, `enclosure.fdm.box`, and `enclosure.cutoutaperture`
- document `cutoutApertureDirection` separately from installation/mating direction
- explain component-relative aperture axes, direction precedence, offsets, depth, and measured CAD bounds
- correct existing connector, switch, footprint, and CAD-model guidance to use the released direction vocabulary
- document appearance as viewer-owned state, with one compatibility Enclosure control affecting base and lid together

## Current compatibility behavior

Core currently emits separate base and lid CAD components sharing a synthetic enclosure owner. Independent base/lid appearance remains deferred until Circuit JSON has an explicit enclosure-part role; the Skill does not present the deferred typed schema as released behavior.

## Validation

- all added relative documentation links resolve
- examples use the released Props/Core authoring API
- repository has no package scripts or pull-request workflows
