### PR TITLE
docs: add antenna element guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -45,6 +45,7 @@ When this Skill is active:
   - Schematic: `schX`, `schY`, `schRotation`, `schOrientation`
 - On large projects (5+ components), use `<schematicsection />` to group components by function (e.g. "Power", "MCU", "IO"). This is one of the most important things for schematic readability. Assign each component a `schSectionName` and manually position all members of a section in close proximity using `schX`/`schY`.
 - When one large chip needs to appear on multiple schematic sheets, declare the `<chip />` once before the sheets, then use one `<schematicbox chipRef=".U1" />` per sheet. Either nest each box inside its `<schematicsheet />`, or keep the elements as siblings and assign the box with `schSheetName`. Pass only that sheet's labels to the box and keep connections addressed to the original chip, such as `U1.VCC`. See the [`<schematicbox />` reference](./elements/schematicbox.md#split-one-chip-across-multiple-schematic-sheets).
+- Use `<antenna />` for a placed, open-ended PCB antenna. Give it a one-pad footprint, define its local copper geometry with `pcbPath`, and connect the circuit to its `.feed` port with a separate `<trace />`. See the [`<antenna />` reference](./elements/antenna.md).
 - Use `<trace />` for connectivity; prefer net connections (`net.GND`, `net.VCC`, etc.) for power/ground.
 
 5) Build and iterate
@@ -91,6 +92,7 @@ When this Skill is active:
 ## Builtin Elements
 
 - [`<analogsimulation />`](./elements/analogsimulation.md)
+- [`<antenna />`](./elements/antenna.md)
 - [`<assembly.device />`](./elements/assemblydevice.md)
 - [`<battery />`](./elements/battery.md)
 - [`<board />`](./elements/board.md)

--- a/elements/antenna.md
+++ b/elements/antenna.md
@@ -1,0 +1,71 @@
+# `<antenna />`
+
+The `<antenna />` element is a single-feed normal component for a placed antenna footprint and an optional open-ended PCB copper path. Prefer it over modeling radiating copper as a one-ended `<trace />`.
+
+## Example: WiFi meander antenna
+
+```tsx
+export default () => (
+  <board width="32mm" height="16mm" minTraceWidth="0.3mm">
+    <chip name="U1" footprint="qfn32" pcbX={-12} />
+
+    <antenna
+      name="ANT1"
+      pcbX={-8}
+      pcbY={-1}
+      footprint={
+        <footprint>
+          <smtpad
+            shape="rect"
+            width="1mm"
+            height="1mm"
+            portHints={["pin1"]}
+          />
+        </footprint>
+      }
+      pcbPath={[
+        { x: 1, y: 0 },
+        { x: 1, y: 5 },
+        { x: 12, y: 5 },
+        { x: 12, y: 3.5 },
+        { x: 3, y: 3.5 },
+        { x: 3, y: 2 },
+        { x: 12, y: 2 },
+        { x: 12, y: 0.5 },
+        { x: 3, y: 0.5 },
+        { x: 3, y: -1 },
+        { x: 12, y: -1 },
+      ]}
+    />
+
+    <trace from=".U1 > .pin1" to=".ANT1 > .feed" />
+  </board>
+)
+```
+
+This geometry demonstrates the API only; it is not a tuned antenna design. Use validated dimensions, stackup, feed impedance, ground clearance, and keepout geometry for production RF work.
+
+## Behavior
+
+- The antenna has one port, `pin1`, with the alias `feed`.
+- For PCB use, give it a one-pad footprint whose pad has `portHints={["pin1"]}`. The pad anchors the antenna feed.
+- `pcbPath` begins at the feed automatically; do not repeat the feed point in the array.
+- `{ x, y }` path entries use local millimeter coordinates relative to the feed. They translate and rotate with `pcbX`, `pcbY`, and `pcbRotation`.
+- Selector-string path entries resolve to global PCB coordinates.
+- `pcbPath` accepts the same point and via entries as a `<trace />` path.
+- Copper width comes from the enclosing board or subcircuit's `minTraceWidth`, falling back to the manufacturing default.
+- Connect another component to `.ANT1 > .feed` with a separate `<trace />`. The radiating path itself remains open-ended.
+
+## Common props
+
+- Identity and rendering: `name`, `footprint`, `symbol`, `cadModel`
+- PCB placement: `pcbX`, `pcbY`, `pcbRotation`, `layer`
+- Antenna copper: `pcbPath`
+- Schematic placement: `schX`, `schY`, `schRotation`, `schOrientation`
+
+## References
+
+- [Antenna props source](https://github.com/tscircuit/props/blob/main/lib/components/antenna.ts)
+- [Antenna core source](https://github.com/tscircuit/core/blob/main/lib/components/normal-components/Antenna.ts)
+- [Element documentation](https://docs.tscircuit.com/elements/antenna)
+- [WiFi antenna guide](https://docs.tscircuit.com/guides/tscircuit-essentials/draw-a-wifi-antenna)


### PR DESCRIPTION
## Summary

- teach agents to use <antenna /> for a placed, open-ended PCB antenna instead of a one-ended <trace /> workaround
- add an antenna element reference with a WiFi meander example
- document the feed port, one-pad footprint, local pcbPath coordinates, rotation, width, and connectivity behavior
- include an RF tuning and clearance caution

## Related

- tscircuit/props#822
- tscircuit/core#3490
- tscircuit/docs#848

## Validation

- git diff --check
- verified every local element link listed in SKILL.md resolves to a file
- confirmed the documented API against the merged props and core implementations
- the example pcbPath and placement behavior were exercised in the core antenna tests