### PR TITLE
Improve routing and copper pour guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -47,6 +47,8 @@ When this Skill is active:
 - When one large chip needs to appear on multiple schematic sheets, declare the `<chip />` once before the sheets, then use one `<schematicbox chipRef=".U1" />` per sheet. Either nest each box inside its `<schematicsheet />`, or keep the elements as siblings and assign the box with `schSheetName`. Pass only that sheet's labels to the box and keep connections addressed to the original chip, such as `U1.VCC`. See the [`<schematicbox />` reference](./elements/schematicbox.md#split-one-chip-across-multiple-schematic-sheets).
 - Use `<antenna />` for a placed, open-ended PCB antenna. Give it a one-pad footprint, define its local copper geometry with `pcbPath`, and connect the circuit to its `.feed` port with a separate `<trace />`. See the [`<antenna />` reference](./elements/antenna.md).
 - Use `<trace />` for connectivity; prefer net connections (`net.GND`, `net.VCC`, etc.) for power/ground.
+- Treat routing and copper-pour generation as separate steps. `automaticPoursEnabled` adds implicit pours after routing for nets marked or recognized as power or ground, and is skipped when PCB routing is disabled. It does not suppress power-net traces, reserve a layer, or make package pins terminate on a plane.
+- For dense packages with dedicated power planes, use `<autoroutingphase autorouter="fanout" />` with `fanoutPourNetMap` and explicit `<copperpour />` elements.
 
 5) Build and iterate
 - Run `tsci check netlist` before `tsci check schematic-placement`, `tsci check placement`, and `tsci build` to catch connectivity issues early.
@@ -61,6 +63,7 @@ When this Skill is active:
   and inspect `placement-unrouted.png` plus each cumulative
   `phase-N-routed.png`. Add `--autorouter-dump-srj all` when the
   SimpleRouteJson input and output for every stage is also needed.
+- Before interpreting a routing experiment, confirm the changed option appears in the effective routing input or diagnostics. If two configurations produce byte-identical output, check for an ignored property or cached result before drawing a physical-layout conclusion.
 - After routing, run `tsci check shorts [file]` to detect unintended shorts between separate PCB copper groups. Omit `[file]` to use the project entrypoint; a prebuilt `*.circuit.json` file is also accepted.
 - A detected short makes `tsci check shorts` exit nonzero. Inspect `checks/check-shorts/bitmap.png` and `checks/check-shorts/pcb.svg`, fix the implicated copper, then rerun the check. Do not dismiss this failure as a generic DRC warning.
 - The default check analyzes Gerber-derived copper on both layers. Use `--mode pcb` for PCB geometry, `--layer top` or `--layer bottom` to narrow the scope, and `--pixels-per-mm <number>` only when a different bitmap resolution is needed.


### PR DESCRIPTION
## Summary

- distinguish post-routing copper pours from trace routing
- point dedicated power planes to fanoutPourNetMap and explicit pours
- guard against drawing conclusions from ignored or cached routing options

Companion docs update: https://github.com/tscircuit/docs/pull/865

## Testing

- git diff --check
- verified the retired preset names do not appear in the skill